### PR TITLE
Fixed 1 issue of type: PYTHON_E251 throughout 1 file in repo.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ ext_modules = []
 if _build_libovr_ == '1':
     cythonize("psychxr/libovr/_libovr.pyx",
               include_path=_sdk_data_['libovr']['include'],
-              compiler_directives = {'embedsignature': True})
+              compiler_directives={'embedsignature': True})
     ext_modules.extend([
         Extension(
             "psychxr.libovr._libovr",


### PR DESCRIPTION
PYTHON_E251: 'unexpected spaces around keyword / parameter equals'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.