### PR TITLE
Fixed 3 issues of type: PYTHON_W391 throughout 3 files in repo.

### DIFF
--- a/demo/rift/libovr_headtracking.py
+++ b/demo/rift/libovr_headtracking.py
@@ -257,4 +257,3 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/demo/rift/libovr_minimal.py
+++ b/demo/rift/libovr_minimal.py
@@ -226,4 +226,3 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/setup.py
+++ b/setup.py
@@ -149,5 +149,3 @@ setup_pars = {
     "cmdclass" : {"build_ext": build_ext}}
 
 setup(**setup_pars)
-
-


### PR DESCRIPTION
PYTHON_W391: 'blank line at end of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.