### PR TITLE
Fixed 2 issues of type: PYTHON_F401 throughout 2 files in repo.

### DIFF
--- a/demo/rift/libovr_minimal.py
+++ b/demo/rift/libovr_minimal.py
@@ -3,7 +3,6 @@
 import OpenGL.GL as GL
 import ctypes
 import glfw
-import numpy as np
 from psychxr.libovr import *
 import sys
 

--- a/psychxr/libovr/__init__.py
+++ b/psychxr/libovr/__init__.py
@@ -23,4 +23,3 @@ __email__ = "cutonem@yorku.ca"
 # -------
 #
 # load exported data from the _libovr extension module into the namespace
-from ._libovr import *


### PR DESCRIPTION
PYTHON_F401: 'Module imported but unused.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.        

It was fixed with <a href='https://github.com/myint/autoflake'>autoflake</a>.        

This fix is probably safe because the module was not called anywhere.  But if the removed module had global side-effects,        these will be missing and could cause issues.        