### PR TITLE
Upgrade to oculus sdk v32

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,32 @@
 This file contains changes introduced to PsychXR for each version. Breaking
 changes may be incompatible with your current code or build environment.
 
+Version 0.2.5 - 2022/10/10
+--------------------------
+
+Overview:
+
+This release is just an enhancement to upgrade the Oculus PC SDK from v23 to v32.
+
+New Features:
+
+- Version bump of the Oculus PC SDK to 32.0 (latest as of this release).
+
+Breaking changes:
+
+- Removed HMD_DK1 and HMD_DKHD due to their removal from the Oculus PC SDK.
+
+Known Issues:
+
+    - Calling `psychxr.drivers.libovr.shutdown()` results in the application
+      quitting with exit code -1073741819 (0xC0000005) on Windows. This seems to
+      only occur after creating an OpenGL swap chain, so it might be related to
+      how the library interacts with the driver. You can ignore calling
+      `shutdown` to circumvent this issue for now, hopefully the `LibOVR`
+      runtime will free up resources associated with your app automatically.
+    - OpenHMD support is incomplete, available only for preview and not
+      recommended for general use yet.
+
 Version 0.2.4 - 2021/07/12
 --------------------------
 

--- a/psychxr/drivers/libovr/include/libovr_hmdinfo.pxi
+++ b/psychxr/drivers/libovr/include/libovr_hmdinfo.pxi
@@ -27,8 +27,6 @@
 
 # HMD types
 HMD_NONE = capi.ovrHmd_None
-HMD_DK1 = capi.ovrHmd_DK1
-HMD_DKHD = capi.ovrHmd_DKHD
 HMD_DK2 = capi.ovrHmd_DK2
 HMD_CB = capi.ovrHmd_CB
 HMD_OTHER = capi.ovrHmd_Other

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ import numpy
 
 # Version string for the project. Make sure this is updated to reflect the
 # project branch version.
-PSYCHXR_VERSION_STRING = '0.2.4rc2'
+PSYCHXR_VERSION_STRING = '0.2.5rc1'
 
 # environment variable values
 ENV_TRUE = '1'


### PR DESCRIPTION
I used libovr.shutdown() without any issues but I did not try using opengl - Let me know if you'd like me to test this to see if the crash has been fixed.
I used psychxr in monoscopic/headlocked mode to draw images in front of the user.
Thanks for your great work on this project :)
